### PR TITLE
feat: add Hypercore (1337) as destination-tag facade over hyperEVM

### DIFF
--- a/src/blockchain/chains.config.ts
+++ b/src/blockchain/chains.config.ts
@@ -11,6 +11,7 @@ export interface RawChainConfig {
   portalAddress?: string; // raw string, normalized lazily by ChainsService
   proverAddress?: string;
   nativeCurrency: { name: string; symbol: string; decimals: number };
+  fulfillmentChainId?: bigint;
 }
 
 export const RAW_CHAIN_CONFIGS: RawChainConfig[] = [
@@ -85,6 +86,15 @@ export const RAW_CHAIN_CONFIGS: RawChainConfig[] = [
     type: ChainType.EVM,
     env: 'production',
     rpcUrl: hyperEvm.rpcUrls.default.http[0],
+    nativeCurrency: hyperEvm.nativeCurrency,
+  },
+  {
+    id: 1337n,
+    name: 'Hypercore',
+    type: ChainType.EVM,
+    env: 'production',
+    rpcUrl: '',
+    fulfillmentChainId: BigInt(hyperEvm.id),
     nativeCurrency: hyperEvm.nativeCurrency,
   },
 

--- a/src/blockchain/chains.service.ts
+++ b/src/blockchain/chains.service.ts
@@ -47,6 +47,15 @@ export class ChainsService implements OnModuleInit {
     return this.chains;
   }
 
+  listSourceChains(): ChainConfig[] {
+    return this.chains.filter(c => c.fulfillmentChainId === undefined);
+  }
+
+  getOperationalChain(chain: ChainConfig): ChainConfig {
+    if (chain.fulfillmentChainId === undefined) return chain;
+    return this.getChainById(chain.fulfillmentChainId);
+  }
+
   getChainById(id: bigint): ChainConfig {
     const chain = this.chains.find(c => c.id === id);
     if (!chain) throw RoutesCliError.unsupportedChain(id);

--- a/src/blockchain/chains.service.ts
+++ b/src/blockchain/chains.service.ts
@@ -24,8 +24,32 @@ export class ChainsService implements OnModuleInit {
       this.normalizeChain(c)
     );
 
+    ChainsService.validateFacadeReferences(this.chains, env);
+
     for (const chain of this.chains) {
       this.registry.registerChainId(chain.id);
+    }
+  }
+
+  // Asserts that every facade chain in the list points at a loaded, non-facade
+  // chain. Catches: unresolved fulfillmentChainId, fulfillment chain filtered
+  // out by env, and chained delegation (facade → facade).
+  static validateFacadeReferences(chains: ChainConfig[], env: string): void {
+    for (const chain of chains) {
+      if (chain.fulfillmentChainId === undefined) continue;
+      const target = chains.find(c => c.id === chain.fulfillmentChainId);
+      if (!target) {
+        throw new Error(
+          `Chain "${chain.name}" (${chain.id}) has fulfillmentChainId ${chain.fulfillmentChainId} ` +
+            `which is not loaded in env "${env}". Add the target chain or remove the facade.`
+        );
+      }
+      if (target.fulfillmentChainId !== undefined) {
+        throw new Error(
+          `Chain "${chain.name}" (${chain.id}) delegates to "${target.name}" (${target.id}), ` +
+            `which is itself a facade. Chained delegation is not supported.`
+        );
+      }
     }
   }
 

--- a/src/blockchain/publisher-factory.service.ts
+++ b/src/blockchain/publisher-factory.service.ts
@@ -20,6 +20,12 @@ export class PublisherFactory {
   ) {}
 
   create(chain: ChainConfig): BasePublisher {
+    if (chain.fulfillmentChainId !== undefined) {
+      throw new Error(
+        `Cannot create a publisher for facade chain "${chain.name}" (${chain.id}). ` +
+          `Call ChainsService.getOperationalChain(chain) first to resolve to the underlying chain.`
+      );
+    }
     const rpcUrl = this.rpcService.getUrl(chain);
     switch (chain.type) {
       case ChainType.EVM:

--- a/src/cli/commands/publish.command.ts
+++ b/src/cli/commands/publish.command.ts
@@ -92,9 +92,14 @@ export class PublishCommand extends CommandRunner {
     this.display.title('🎨 Interactive Intent Publishing');
 
     const allChains = this.chains.listChains();
+    const sourceChains = this.chains.listSourceChains();
     const sourceChain = options.source
       ? this.chains.resolveChain(options.source)
-      : await this.prompt.selectChain(allChains, 'Select source chain:');
+      : await this.prompt.selectChain(sourceChains, 'Select source chain:');
+
+    if (sourceChain.fulfillmentChainId !== undefined) {
+      throw new Error(`${sourceChain.name} cannot be a source chain — it has no RPC of its own.`);
+    }
 
     const destChain = options.destination
       ? this.chains.resolveChain(options.destination)
@@ -103,10 +108,15 @@ export class PublishCommand extends CommandRunner {
           'Select destination chain:'
         );
 
+    // For facade chains (e.g. Hypercore), all operational lookups delegate to the
+    // underlying chain (e.g. hyperEVM). Only `destChain.id` carries the facade tag
+    // through to the published intent's `destination` field and the quote request.
+    const destOp = this.chains.getOperationalChain(destChain);
+
     const tokens = Object.values(TOKEN_CONFIGS);
 
     this.display.section('📏 Route Configuration (Destination Chain)');
-    const routeToken = await this.prompt.selectToken(destChain, tokens, 'route');
+    const routeToken = await this.prompt.selectToken(destOp, tokens, 'route');
 
     this.display.section('💰 Reward Configuration (Source Chain)');
     const rewardToken = await this.prompt.selectToken(sourceChain, tokens, 'reward');
@@ -116,15 +126,13 @@ export class PublishCommand extends CommandRunner {
     );
 
     this.display.section('👤 Recipient Configuration');
-    const destKey =
-      resolveKey(options, destChain.type) ?? this.config.getKeyForChainType(destChain.type);
-    const recipientDefault = destKey ? deriveAddress(destKey, destChain.type) : undefined;
+    const destKey = resolveKey(options, destOp.type) ?? this.config.getKeyForChainType(destOp.type);
+    const recipientDefault = destKey ? deriveAddress(destKey, destOp.type) : undefined;
     const recipientRaw =
-      options.recipient ??
-      (await this.prompt.inputAddress(destChain, 'recipient', recipientDefault));
+      options.recipient ?? (await this.prompt.inputAddress(destOp, 'recipient', recipientDefault));
     const recipient = this.normalizer.normalize(
       recipientRaw as Parameters<typeof this.normalizer.normalize>[0],
-      destChain.type
+      destOp.type
     );
 
     const rawKey =
@@ -174,14 +182,14 @@ export class PublishCommand extends CommandRunner {
         routeToken.decimals
       );
 
-      const destPortal = destChain.portalAddress!;
+      const destPortal = destOp.portalAddress!;
       const routeTokenUniversal = this.normalizer.normalize(
         routeToken.address as Parameters<typeof this.normalizer.normalize>[0],
-        destChain.type
+        destOp.type
       );
 
       const { encodedRoute: manualEncodedRoute } = this.intentBuilder.buildManualRoute({
-        destChain,
+        destChain: destOp,
         recipient,
         routeToken: routeTokenUniversal,
         routeAmount,

--- a/src/shared/types/chain-config.ts
+++ b/src/shared/types/chain-config.ts
@@ -14,4 +14,9 @@ export interface ChainConfig {
     symbol: string;
     decimals: number;
   };
+  // If set, this chain has no RPC/portal of its own. All operational lookups
+  // (RPC URL, portal contract, fulfillment events, token catalog) delegate to
+  // the chain referenced by this id. Only the `destination` field of the
+  // published intent preserves this chain's id.
+  fulfillmentChainId?: bigint;
 }

--- a/src/status/status.service.ts
+++ b/src/status/status.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { IntentStatus } from '@/blockchain/base.publisher';
+import { ChainsService } from '@/blockchain/chains.service';
 import { PublisherFactory } from '@/blockchain/publisher-factory.service';
 import { ChainConfig } from '@/shared/types';
 
@@ -8,11 +9,19 @@ export { IntentStatus };
 
 @Injectable()
 export class StatusService {
-  constructor(private readonly publisherFactory: PublisherFactory) {}
+  constructor(
+    private readonly publisherFactory: PublisherFactory,
+    private readonly chainsService: ChainsService
+  ) {}
 
   async getStatus(intentHash: string, chain: ChainConfig): Promise<IntentStatus> {
-    const publisher = this.publisherFactory.create(chain);
-    return publisher.getStatus(intentHash, chain);
+    // Facade chains (e.g. Hypercore) have no RPC of their own — redirect status
+    // lookups to the operational chain. Forward the original chain's portal as
+    // an override so a quote-supplied portal (set on the original chain) still
+    // wins over the operational chain's default.
+    const opChain = this.chainsService.getOperationalChain(chain);
+    const publisher = this.publisherFactory.create(opChain);
+    return publisher.getStatus(intentHash, opChain, chain.portalAddress);
   }
 
   async watch(

--- a/tests/blockchain/chains.service.test.ts
+++ b/tests/blockchain/chains.service.test.ts
@@ -1,0 +1,84 @@
+import { ChainsService } from '@/blockchain/chains.service';
+import { ChainConfig, ChainType } from '@/shared/types';
+
+const HYPERCORE_ID = 1337n;
+const HYPER_EVM_ID = 999n;
+
+function makeChain(
+  overrides: Partial<ChainConfig> & Pick<ChainConfig, 'id' | 'name'>
+): ChainConfig {
+  return {
+    type: ChainType.EVM,
+    env: 'production',
+    rpcUrl: 'https://example.test',
+    nativeCurrency: { name: 'Test', symbol: 'TST', decimals: 18 },
+    ...overrides,
+  };
+}
+
+function buildService(): ChainsService {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const config: any = { getChainsEnv: () => 'production' };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const normalizer: any = { normalize: (addr: unknown) => addr };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const registry: any = { registerChainId: () => undefined };
+  const service = new ChainsService(config, normalizer, registry);
+  service.onModuleInit();
+  return service;
+}
+
+describe('ChainsService — facade chain helpers', () => {
+  const service = buildService();
+
+  it('listSourceChains excludes facade chains', () => {
+    const ids = service.listSourceChains().map(c => c.id);
+    expect(ids).toContain(HYPER_EVM_ID);
+    expect(ids).not.toContain(HYPERCORE_ID);
+  });
+
+  it('listChains still includes facade chains (for destination pickers)', () => {
+    const ids = service.listChains().map(c => c.id);
+    expect(ids).toContain(HYPERCORE_ID);
+    expect(ids).toContain(HYPER_EVM_ID);
+  });
+
+  it('getOperationalChain is identity for non-facade chains', () => {
+    const hyperEvm = service.getChainById(HYPER_EVM_ID);
+    expect(service.getOperationalChain(hyperEvm)).toBe(hyperEvm);
+  });
+
+  it('getOperationalChain redirects facade chains to their target', () => {
+    const hypercore = service.getChainById(HYPERCORE_ID);
+    const op = service.getOperationalChain(hypercore);
+    expect(op.id).toBe(HYPER_EVM_ID);
+  });
+});
+
+describe('ChainsService.validateFacadeReferences', () => {
+  it('passes for a clean configuration', () => {
+    const chains: ChainConfig[] = [
+      makeChain({ id: 1n, name: 'A' }),
+      makeChain({ id: 2n, name: 'B', fulfillmentChainId: 1n }),
+    ];
+    expect(() => ChainsService.validateFacadeReferences(chains, 'production')).not.toThrow();
+  });
+
+  it('throws when fulfillmentChainId points at a missing chain', () => {
+    const chains: ChainConfig[] = [makeChain({ id: 2n, name: 'Orphan', fulfillmentChainId: 999n })];
+    expect(() => ChainsService.validateFacadeReferences(chains, 'production')).toThrow(
+      /fulfillmentChainId 999.*not loaded/i
+    );
+  });
+
+  it('throws on chained delegation (facade → facade)', () => {
+    const chains: ChainConfig[] = [
+      makeChain({ id: 1n, name: 'Real' }),
+      makeChain({ id: 2n, name: 'B', fulfillmentChainId: 1n }),
+      makeChain({ id: 3n, name: 'A', fulfillmentChainId: 2n }),
+    ];
+    expect(() => ChainsService.validateFacadeReferences(chains, 'production')).toThrow(
+      /chained delegation is not supported/i
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Hypercore (chainId 1337) as a selectable destination chain in \`routes publish\`. Hypercore has no RPC of its own; solvers fulfill the intent on hyperEVM and deposit the fulfilled funds into Hypercore. From the CLI's perspective a Hypercore-destination intent is identical to a hyperEVM-destination intent — only the destination chainId tag differs.
- Modeled as a **facade \`ChainConfig\`** with a new optional \`fulfillmentChainId\` field pointing at hyperEVM. The presence of that field is the single signal that "this chain has no own RPC; delegate operations." Keeps tokens as a single source of truth (no duplicate '1337' entries in \`TOKEN_CONFIGS\`) and makes future "real chain only" enumerations a one-line filter.
- Source picker excludes facade chains by construction; destination prompts and status tracking transparently redirect to the operational chain (hyperEVM). The facade chainId is preserved only in the quote request and the published intent's \`destination\` field.

## Files touched

- \`src/shared/types/chain-config.ts\` — add \`fulfillmentChainId?: bigint\`.
- \`src/blockchain/chains.config.ts\` — add Hypercore entry pointing to hyperEVM.
- \`src/blockchain/chains.service.ts\` — add \`listSourceChains()\` and \`getOperationalChain(chain)\`.
- \`src/cli/commands/publish.command.ts\` — wire source/destination through the facade resolution.
- \`src/status/status.service.ts\` — redirect facade-chain status lookups to the operational chain.

## Test plan

- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` clean on changed files
- [x] \`pnpm test:unit\` — 61/61 tests pass
- [x] Interactive smoke test (confirmed by author): publishing an intent with destination Hypercore picks hyperEVM tokens, fulfillment is watched on hyperEVM RPC, and the on-chain intent carries \`destination=1337\`.
- [x] \`routes publish --source Hypercore\` rejects with a clear "cannot be a source chain" error.
- [x] \`routes chains\` shows Hypercore (1337) in the listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)