### PR TITLE
fix: point postinstall at scripts/ and ship it in the published tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
   },
   "files": [
     "bundle",
+    "scripts/postinstall.js",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc --noEmit && ncc build src/main.ts -o bundle --no-cache && cp scripts/postinstall.js bundle/postinstall.js",
+    "build": "tsc --noEmit && ncc build src/main.ts -o bundle --no-cache",
     "dev": "ts-node --transpile-only -r tsconfig-paths/register src/main.ts",
     "dev:testnet": "NODE_CHAINS_ENV=development ts-node --transpile-only -r tsconfig-paths/register src/main.ts",
     "start": "node bundle/index.js",
@@ -31,7 +32,7 @@
     "typecheck": "tsc --noEmit",
     "prepare": "husky",
     "docs": "typedoc",
-    "postinstall": "node bundle/postinstall.js"
+    "postinstall": "node scripts/postinstall.js"
   },
   "keywords": [
     "blockchain",


### PR DESCRIPTION
## Summary

- Restores `postinstall` to `node scripts/postinstall.js` so fresh `pnpm install` (CI and dev) works. \`bundle/\` is gitignored and only built by \`pnpm build\`, which runs *after* \`install\`, so \`node bundle/postinstall.js\` (introduced in b4ca912) fails on every fresh checkout — every PR since 2026-04-06 has hit this.
- Re-adds \`scripts/postinstall.js\` to the \`files\` allowlist so it ships in the published npm tarball, preserving b4ca912's original goal: end users running \`npm install -g eco-routes-cli\` still see the ECO logo on install.
- Drops the now-unnecessary \`cp scripts/postinstall.js bundle/postinstall.js\` step from \`build\`.

## Why this is safer than just flipping the path back

The naive fix (just changing \`postinstall\` back to \`scripts/...\`) would fix dev install but **break end-user install** for the next published version, because b4ca912 also removed \`scripts/postinstall.js\` from the \`files\` array — the published tarball wouldn't contain it. This PR re-adds it to \`files\`, so both scenarios work:

| | Before this PR | After this PR |
|---|---|---|
| Dev / CI install | ❌ \`bundle/postinstall.js\` doesn't exist yet | ✅ \`scripts/postinstall.js\` is in the repo |
| End-user \`npm i -g\` | ✅ \`bundle/postinstall.js\` shipped via \`bundle\` | ✅ \`scripts/postinstall.js\` shipped via \`files\` allowlist |

## Test plan

- [x] \`pnpm install\` in a fresh clone succeeds (manually verified locally; CI run on this PR is the real proof)
- [ ] CI passes on this PR
- [ ] After merge, next published version still prints the logo on \`npm i -g eco-routes-cli\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)