### PR TITLE
feat: add feature:hypercore command

### DIFF
--- a/src/cli/cli.module.ts
+++ b/src/cli/cli.module.ts
@@ -6,6 +6,7 @@ import { StatusModule } from '@/status/status.module';
 
 import { ChainsCommand } from './commands/chains.command';
 import { ConfigCommand } from './commands/config.command';
+import { FeatureHypercoreCommand } from './commands/feature-hypercore.command';
 import { PublishCommand } from './commands/publish.command';
 import { StatusCommand } from './commands/status.command';
 import { TokensCommand } from './commands/tokens.command';
@@ -19,6 +20,7 @@ import { PromptService } from './services/prompt.service';
     PromptService,
     IntentPublishFlow,
     PublishCommand,
+    FeatureHypercoreCommand,
     StatusCommand,
     ConfigCommand,
     ChainsCommand,

--- a/src/cli/commands/feature-hypercore.command.ts
+++ b/src/cli/commands/feature-hypercore.command.ts
@@ -1,0 +1,113 @@
+import { Injectable } from '@nestjs/common';
+
+import { Command, CommandRunner, Option } from 'nest-commander';
+import { hyperEvm } from 'viem/chains';
+
+import { ChainsService } from '@/blockchain/chains.service';
+
+import { DisplayService } from '../services/display.service';
+import { IntentPublishFlow, PublishFlowOptions } from '../services/intent-publish-flow.service';
+import { PromptService } from '../services/prompt.service';
+
+const HYPERCORE_CHAIN_ID = 1337n;
+const HYPER_EVM_CHAIN_ID = BigInt(hyperEvm.id);
+
+interface FeatureHypercoreOptions extends PublishFlowOptions {
+  source?: string;
+}
+
+@Injectable()
+@Command({
+  name: 'feature:hypercore',
+  description: 'Publish an intent that deposits into Hypercore on fulfillment',
+})
+export class FeatureHypercoreCommand extends CommandRunner {
+  constructor(
+    private readonly chains: ChainsService,
+    private readonly prompt: PromptService,
+    private readonly display: DisplayService,
+    private readonly flow: IntentPublishFlow
+  ) {
+    super();
+  }
+
+  async run(_params: string[], options: FeatureHypercoreOptions): Promise<void> {
+    this.display.title('🎯 Hypercore Deposit Intent');
+
+    const allChains = this.chains.listChains();
+    const sourceChain = options.source
+      ? this.chains.resolveChain(options.source)
+      : await this.prompt.selectChain(
+          allChains.filter(c => c.id !== HYPER_EVM_CHAIN_ID),
+          'Select source chain:'
+        );
+
+    if (sourceChain.id === HYPER_EVM_CHAIN_ID) {
+      throw new Error('HyperEVM cannot be a source for a Hypercore deposit intent.');
+    }
+
+    // Operationally publish/watch on hyperEVM (real RPC, real portal, real
+    // tokens). The Hypercore tag (1337) goes on the quote request only — the
+    // signal to the solver pipeline that this should be priced/handled as a
+    // Hypercore deposit. The on-chain intent stays a regular hyperEVM intent.
+    const destChain = this.chains.getChainById(HYPER_EVM_CHAIN_ID);
+
+    await this.flow.publish({
+      sourceChain,
+      destChain,
+      options,
+      overrides: { quoteDestinationChainIdOverride: HYPERCORE_CHAIN_ID },
+    });
+  }
+
+  @Option({ flags: '-s, --source <chain>', description: 'Source chain name or ID' })
+  parseSource(val: string): string {
+    return val;
+  }
+
+  @Option({ flags: '-k, --private-key <key>', description: 'EVM private key (overrides env)' })
+  parsePrivateKey(val: string): string {
+    return val;
+  }
+
+  @Option({ flags: '--private-key-tvm <key>', description: 'TVM private key (overrides env)' })
+  parsePrivateKeyTvm(val: string): string {
+    return val;
+  }
+
+  @Option({ flags: '--private-key-svm <key>', description: 'SVM private key (overrides env)' })
+  parsePrivateKeySvm(val: string): string {
+    return val;
+  }
+
+  @Option({ flags: '--recipient <address>', description: 'Recipient address on hyperEVM' })
+  parseRecipient(val: string): string {
+    return val;
+  }
+
+  @Option({
+    flags: '--portal-address <address>',
+    description: 'Portal contract address on the source chain',
+  })
+  parsePortalAddress(val: string): string {
+    return val;
+  }
+
+  @Option({
+    flags: '--prover-address <address>',
+    description: 'Prover contract address on the source chain',
+  })
+  parseProverAddress(val: string): string {
+    return val;
+  }
+
+  @Option({ flags: '--dry-run', description: 'Validate without broadcasting' })
+  parseDryRun(): boolean {
+    return true;
+  }
+
+  @Option({ flags: '-w, --watch', description: 'Watch for fulfillment after publishing' })
+  parseWatch(): boolean {
+    return true;
+  }
+}

--- a/src/cli/services/intent-publish-flow.service.ts
+++ b/src/cli/services/intent-publish-flow.service.ts
@@ -50,6 +50,12 @@ export interface PublishFlowOverrides {
   routeToken?: TokenSelection;
   rewardAmount?: bigint;
   recipientRaw?: string;
+  // When set, this chainId is sent as the `destination` in the quote request
+  // (the signal to the quote/solver pipeline that this is e.g. a Hypercore
+  // intent). The published on-chain intent's `destination` field always uses
+  // the operational destChain's id — solver echoes from the quote response
+  // are ignored when this override is in effect.
+  quoteDestinationChainIdOverride?: bigint;
 }
 
 export interface PublishFlowResult {
@@ -100,6 +106,11 @@ export class IntentPublishFlow {
 
     const { publishKeyHandle, senderAddress } = this.resolveSender(sourceChain, options);
 
+    // chainId sent in the quote request only — feature commands tag the quote
+    // with a synthetic destination (e.g. 1337 for Hypercore) while the actual
+    // on-chain intent below targets the operational destChain.
+    const quoteDestinationChainId = overrides.quoteDestinationChainIdOverride ?? destChain.id;
+
     const {
       encodedRoute,
       sourcePortal: portalFromQuote,
@@ -108,6 +119,7 @@ export class IntentPublishFlow {
     } = await this.fetchQuoteOrManualRoute({
       sourceChain,
       destChain,
+      quoteDestinationChainId,
       rewardToken,
       routeToken,
       rewardAmount,
@@ -144,9 +156,15 @@ export class IntentPublishFlow {
       return null;
     }
 
-    const destinationChainId = quote?.destinationChainId
-      ? BigInt(quote.destinationChainId)
-      : destChain.id;
+    // When the caller overrode the quote's destination, ignore any echo-back
+    // from the quote response — the on-chain intent should always target the
+    // operational destChain.
+    const destinationChainId =
+      overrides.quoteDestinationChainIdOverride !== undefined
+        ? destChain.id
+        : quote?.destinationChainId
+          ? BigInt(quote.destinationChainId)
+          : destChain.id;
 
     const publisher = this.publisherFactory.create(sourceChain);
     const result = await publisher.publish(
@@ -217,6 +235,7 @@ export class IntentPublishFlow {
   private async fetchQuoteOrManualRoute(args: {
     sourceChain: ChainConfig;
     destChain: ChainConfig;
+    quoteDestinationChainId: bigint;
     rewardToken: TokenSelection;
     routeToken: TokenSelection;
     rewardAmount: bigint;
@@ -232,6 +251,7 @@ export class IntentPublishFlow {
     const {
       sourceChain,
       destChain,
+      quoteDestinationChainId,
       rewardToken,
       routeToken,
       rewardAmount,
@@ -244,7 +264,7 @@ export class IntentPublishFlow {
       this.display.spinner('Getting quote...');
       const quote = await this.quoteService.getQuote({
         source: sourceChain.id,
-        destination: destChain.id,
+        destination: quoteDestinationChainId,
         amount: rewardAmount,
         funder: senderAddress,
         recipient: recipientRaw,

--- a/tests/cli/feature-hypercore.command.test.ts
+++ b/tests/cli/feature-hypercore.command.test.ts
@@ -1,0 +1,84 @@
+import { hyperEvm } from 'viem/chains';
+
+import { ChainsService } from '@/blockchain/chains.service';
+import { FeatureHypercoreCommand } from '@/cli/commands/feature-hypercore.command';
+import { ChainConfig, ChainType } from '@/shared/types';
+
+const HYPER_EVM_ID = BigInt(hyperEvm.id);
+
+const HYPER_EVM: ChainConfig = {
+  id: HYPER_EVM_ID,
+  name: 'HyperEVM',
+  type: ChainType.EVM,
+  env: 'production',
+  rpcUrl: 'https://rpc.hyperliquid.xyz/evm',
+  nativeCurrency: { name: 'HYPE', symbol: 'HYPE', decimals: 18 },
+};
+
+const BASE: ChainConfig = {
+  id: 8453n,
+  name: 'Base',
+  type: ChainType.EVM,
+  env: 'production',
+  rpcUrl: 'https://mainnet.base.org',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+};
+
+interface CommandFixture {
+  command: FeatureHypercoreCommand;
+  chains: ChainsService;
+  prompt: { selectChain: jest.Mock };
+  flow: { publish: jest.Mock };
+}
+
+function buildCommand(): CommandFixture {
+  const chains = {
+    resolveChain: jest.fn((nameOrId: string) =>
+      nameOrId.toLowerCase() === 'hyperevm' ? HYPER_EVM : BASE
+    ),
+    listChains: jest.fn().mockReturnValue([BASE, HYPER_EVM]),
+    getChainById: jest.fn((id: bigint) => {
+      if (id === HYPER_EVM_ID) return HYPER_EVM;
+      throw new Error(`unknown chain ${id}`);
+    }),
+  } as unknown as ChainsService;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prompt: any = { selectChain: jest.fn().mockResolvedValue(BASE) };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const display: any = { title: () => undefined };
+  const flow = { publish: jest.fn().mockResolvedValue(null) };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const command = new FeatureHypercoreCommand(chains, prompt, display, flow as any);
+  return { command, chains, prompt, flow };
+}
+
+describe('FeatureHypercoreCommand', () => {
+  it('publishes via hyperEVM with quoteDestinationChainIdOverride=1337', async () => {
+    const { command, flow, chains } = buildCommand();
+    await command.run([], { source: 'Base' });
+
+    expect(chains.getChainById).toHaveBeenCalledWith(HYPER_EVM_ID);
+    expect(flow.publish).toHaveBeenCalledTimes(1);
+    const call = flow.publish.mock.calls[0][0] as {
+      destChain: ChainConfig;
+      overrides: { quoteDestinationChainIdOverride: bigint };
+    };
+    expect(call.destChain.id).toBe(HYPER_EVM_ID);
+    expect(call.overrides.quoteDestinationChainIdOverride).toBe(1337n);
+  });
+
+  it('rejects HyperEVM as a source', async () => {
+    const { command } = buildCommand();
+    await expect(command.run([], { source: 'HyperEVM' })).rejects.toThrow(/cannot be a source/i);
+  });
+
+  it('excludes HyperEVM from the interactive source picker', async () => {
+    const { command, prompt } = buildCommand();
+    await command.run([], {});
+    const choicesArg = prompt.selectChain.mock.calls[0][0] as ChainConfig[];
+    expect(choicesArg.map(c => c.id)).not.toContain(HYPER_EVM_ID);
+    expect(choicesArg.map(c => c.id)).toContain(8453n);
+  });
+});

--- a/tests/cli/intent-publish-flow.test.ts
+++ b/tests/cli/intent-publish-flow.test.ts
@@ -208,6 +208,30 @@ describe('IntentPublishFlow.publish', () => {
     expect(publisherFactory.create).not.toHaveBeenCalled();
   });
 
+  it('quoteDestinationChainIdOverride only affects the quote request — published intent uses destChain.id', async () => {
+    const { flow, quoteService, publisher } = buildFlow();
+    await flow.publish({
+      sourceChain: SOURCE_CHAIN,
+      destChain: DEST_CHAIN, // id 10n
+      options: { privateKey: TEST_PRIVATE_KEY },
+      overrides: {
+        rewardToken: TOKEN_USDC,
+        routeToken: TOKEN_USDC,
+        rewardAmount: 1_000_000n,
+        recipientRaw: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        quoteDestinationChainIdOverride: 1337n,
+      },
+    });
+    // Quote request was tagged with the override.
+    const quoteCall = quoteService.getQuote.mock.calls[0][0] as { destination: bigint };
+    expect(quoteCall.destination).toBe(1337n);
+    // Published intent uses destChain.id, NOT the override (and not the quote's
+    // echoed destinationChainId — that's intentionally ignored when override
+    // is in effect, in case the solver echoes back the synthetic tag).
+    const publishCall = publisher.publish.mock.calls[0] as [bigint, bigint, ...unknown[]];
+    expect(publishCall[1]).toBe(DEST_CHAIN.id);
+  });
+
   it('throws when the user does not confirm', async () => {
     const { flow, prompt, publisher } = buildFlow();
     prompt.confirmPublish.mockResolvedValueOnce(false);


### PR DESCRIPTION
## Summary

Adds a dedicated subcommand for publishing intents that deposit into Hypercore on fulfillment:

```
routes feature:hypercore [--source <chain>] [-w] [...]
```

## Design

The Hypercore "destination" is a tag for the quote pipeline, not a real chain. The command runs the publish flow operationally against hyperEVM and uses a single small override (`quoteDestinationChainIdOverride`) to tag the quote request with `1337`. The on-chain intent stays a uniform hyperEVM intent (`destination: 999`) — solver echoes don't leak through.

| | Quote request | On-chain intent | Token list / RPC / portal / watch |
|---|---|---|---|
| `routes publish` (regular) | destChain.id | destChain.id | destChain |
| `feature:hypercore` | **1337** | **999** (hyperEVM) | hyperEVM |

Concretely, the command:
- Excludes hyperEVM from the source picker (you can't publish to yourself).
- Resolves hyperEVM as `destChain` via `chains.getChainById(BigInt(hyperEvm.id))`.
- Calls `flow.publish({ sourceChain, destChain: hyperEVM, options, overrides: { quoteDestinationChainIdOverride: 1337n } })`.

## Files

- **NEW** `src/cli/commands/feature-hypercore.command.ts` (~110 lines).
- **MODIFIED** `src/cli/services/intent-publish-flow.service.ts` — new optional `quoteDestinationChainIdOverride` on `PublishFlowOverrides`, plumbed into the quote request and guarded against echo-back.
- **MODIFIED** `src/cli/cli.module.ts` — register the new command.
- **NEW** `tests/cli/feature-hypercore.command.test.ts` (3 tests).
- **MODIFIED** `tests/cli/intent-publish-flow.test.ts` (+1 test locking down override semantics).

## Verification

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean on changed files
- [x] `pnpm test:unit` — 69 passing (65 prior + 3 feature command + 1 override semantics)
- [x] Manual smoke: published a Hypercore intent end-to-end. Quote received with `destination: 1337`, intent published with `destination: 999`, fulfillment confirmed on hyperEVM.

## Stacked on

PR #21 (`refactor/intent-publish-flow`). This PR's base is `refactor/intent-publish-flow`; once that merges, GitHub will re-target this PR onto main automatically.

## Known follow-up (separate PR)

HyperEVM's `eth_getLogs` has a max block range of 1000, but the existing watch flow in `evm.publisher.ts:getStatus` sends `fromBlock: currentBlock - 1000n` without a `toBlock`, so the actual range becomes `1000 + N` (N = blocks produced between `getBlockNumber()` and the RPC call). Will fix in a tiny separate PR off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)