### PR TITLE
fix: pin eth_getLogs range so HyperEVM watch flow doesn't crash

### DIFF
--- a/src/blockchain/evm/evm.publisher.ts
+++ b/src/blockchain/evm/evm.publisher.ts
@@ -277,11 +277,17 @@ export class EvmPublisher extends BasePublisher {
     try {
       const currentBlock = await publicClient.getBlockNumber();
 
+      // Pin both bounds so the queried range is deterministic. Without an
+      // explicit toBlock viem defaults to "latest", which the RPC evaluates
+      // at request time — so the actual range becomes 1000 + N (N = blocks
+      // produced between getBlockNumber() and the RPC call). HyperEVM caps
+      // eth_getLogs at 1000 blocks and rejects ranges of 1001+.
       const events = await publicClient.getContractEvents({
         address: evmPortalAddress,
         abi: portalAbi,
         eventName: 'IntentFulfilled',
-        fromBlock: currentBlock - 1_000n,
+        fromBlock: currentBlock - 999n,
+        toBlock: currentBlock,
         args: { intentHash: intentHash as Hex },
       });
 


### PR DESCRIPTION
## Summary

`EvmPublisher.getStatus` called `getContractEvents` with `fromBlock: currentBlock - 1_000n` and no `toBlock`. Viem defaults `toBlock` to `"latest"`, which the RPC evaluates at request-time — so the actual queried range was `1000 + N` blocks, where N = blocks produced between the `getBlockNumber()` call and the `eth_getLogs` call. HyperEVM caps `eth_getLogs` at exactly 1000 blocks, so the watch flow always crashed on hyperEVM destinations:

```
InvalidParamsRpcError: Invalid parameters were provided to the RPC method.
Details: query exceeds max block range 1000
```

## Fix

Pin both bounds: `fromBlock: currentBlock - 999n, toBlock: currentBlock`. Range is deterministic at exactly 1000.

## Coverage

`StatusService.watch` polls every 10s and re-fetches `currentBlock` each call. Each poll's window slides forward, and any event at block X is visible to any poll where `currentBlock ∈ [X, X + 999]`. With 10s polls and any reasonable block time, that's guaranteed coverage. The narrow race window between `getBlockNumber()` and the RPC call (where the original query had a small advantage) is covered by the next poll 10s later.

For other chains (10k+ block limits), behavior is unchanged in practice — the original was already searching the last ~1000 blocks; this just trims the upper bound.

## Verification

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Manual smoke (please verify): `routes publish -w` to a hyperEVM destination — watch loop runs without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)