### PR TITLE
feat: add Plasma mainnet chain and USDT0 token

### DIFF
--- a/src/blockchain/chains.config.ts
+++ b/src/blockchain/chains.config.ts
@@ -97,6 +97,16 @@ export const RAW_CHAIN_CONFIGS: RawChainConfig[] = [
     rpcUrl: hyperEvm.rpcUrls.default.http[0],
     nativeCurrency: hyperEvm.nativeCurrency,
   },
+  {
+    id: 9745n,
+    name: 'Plasma',
+    type: ChainType.EVM,
+    env: 'production',
+    rpcUrl: 'https://rpc.plasma.to',
+    portalAddress: '0x399Dbd5DF04f83103F77A58cBa2B7c4d3cdede97',
+    provers: { Hyperlane: '0xC972B26C1E208845Ca8C18c6B83466bFCeED8c2F' },
+    nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  },
 
   // EVM - Development
   {

--- a/src/config/tokens.config.ts
+++ b/src/config/tokens.config.ts
@@ -139,6 +139,16 @@ export const TOKEN_CONFIGS: Record<string, TokenConfig> = {
       ), // BNB Smart Chain
     },
   },
+  USDT0: {
+    symbol: 'USDT0',
+    name: 'USDT0',
+    decimals: 6,
+    addresses: {
+      '9745': AddressNormalizer.normalizeEvm(
+        '0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb' as EvmAddress
+      ), // Plasma
+    },
+  },
   ETH: {
     symbol: 'ETH',
     name: 'Ether',

--- a/tests/core/config/plasma-mainnet.test.ts
+++ b/tests/core/config/plasma-mainnet.test.ts
@@ -1,0 +1,46 @@
+import { RAW_CHAIN_CONFIGS } from '@/blockchain/chains.config';
+import { TOKEN_CONFIGS } from '@/config/tokens.config';
+import { ChainType } from '@/shared/types';
+
+describe('Plasma mainnet chain config', () => {
+  const plasma = RAW_CHAIN_CONFIGS.find(c => c.id === 9745n);
+
+  it('exists in RAW_CHAIN_CONFIGS', () => {
+    expect(plasma).toBeDefined();
+  });
+
+  it('has correct static properties', () => {
+    expect(plasma).toMatchObject({
+      id: 9745n,
+      name: 'Plasma',
+      type: ChainType.EVM,
+      env: 'production',
+      rpcUrl: 'https://rpc.plasma.to',
+      portalAddress: '0x399Dbd5DF04f83103F77A58cBa2B7c4d3cdede97',
+    });
+  });
+
+  it('has Hyperlane prover address', () => {
+    expect(plasma?.provers?.Hyperlane).toBe('0xC972B26C1E208845Ca8C18c6B83466bFCeED8c2F');
+  });
+});
+
+describe('USDT0 token config', () => {
+  const usdt0 = TOKEN_CONFIGS['USDT0'];
+
+  it('exists in TOKEN_CONFIGS', () => {
+    expect(usdt0).toBeDefined();
+  });
+
+  it('has correct symbol and decimals', () => {
+    expect(usdt0.symbol).toBe('USDT0');
+    expect(usdt0.decimals).toBe(6);
+  });
+
+  it('has a normalized address for Plasma mainnet (chain 9745)', () => {
+    const addr = usdt0.addresses['9745'];
+    expect(addr).toBeDefined();
+    expect(addr).toMatch(/^0x[0-9a-fA-F]{64}$/);
+    expect(addr.toLowerCase()).toContain('b8ce59fc3717ada4c02eadf9682a9e934f625ebb');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Plasma mainnet (chain ID 9745) to the production EVM chains with RPC `https://rpc.plasma.to`, prod portal, and Hyperlane prover
- Adds USDT0 token (6 decimals, `0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb`) deployed on Plasma mainnet

## Test plan
- [ ] `eco-routes-cli chains` lists Plasma in production chains
- [ ] `eco-routes-cli tokens` lists USDT0 with correct address for chain 9745

🤖 Generated with [Claude Code](https://claude.com/claude-code)