### PR TITLE
feat: support the Tron v2.6 Polymer corridor (PAR-393)

### DIFF
--- a/src/blockchain/chains.config.ts
+++ b/src/blockchain/chains.config.ts
@@ -50,7 +50,15 @@ export const RAW_CHAIN_CONFIGS: RawChainConfig[] = [
     env: 'production',
     rpcUrl: 'https://mainnet.base.org',
     portalAddress: '0x399Dbd5DF04f83103F77A58cBa2B7c4d3cdede97', // prod portal
-    provers: { LayerZero: '0x0C4E3063239c9f4f323A956C79738916594D8Fd4' }, // prod prover
+    provers: {
+      LayerZero: '0x0C4E3063239c9f4f323A956C79738916594D8Fd4', // prod prover
+      // v2.6 Tron<>EVM Polymer mesh (Tron corridor endpoint). The same CREATE3
+      // prover exists on Ethereum/Optimism/Arbitrum/Polygon but is deliberately
+      // not listed there: a second common prover type between two EVM chains
+      // would break the single-common-prover auto-selection in the manual
+      // fallback. Use --prover-address 0xE3e4... on those chains if needed.
+      Polymer: '0xE3e4e6F284f1c8E17bafE4268EB98c36886B4d8B',
+    },
     nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
   },
   {
@@ -156,8 +164,11 @@ export const RAW_CHAIN_CONFIGS: RawChainConfig[] = [
     type: ChainType.TVM,
     env: 'production',
     rpcUrl: 'https://api.trongrid.io',
-    portalAddress: 'TTXNcSeX5aYb1ETWYjcX3fvumynWoyFgYw', // prod portal
-    provers: { LayerZero: 'TFu38RELzp7jdR9s7vj4JSpw2kFuTSAq3E' }, // prod prover
+    // v2.6 Tron<>EVM Polymer mesh. Portal and prover must stay paired: the old
+    // LayerZero prover (TFu38RELzp7jdR9s7vj4JSpw2kFuTSAq3E) belongs to the old
+    // portal (TTXNcSeX5aYb1ETWYjcX3fvumynWoyFgYw) and cannot prove v2.6 intents.
+    portalAddress: 'TT6jKgnBXoj7vZ7m2Yioq5mxTfrDpgir44',
+    provers: { Polymer: 'TLvVHqZZbs4Juf7umHYAepYgZkSdKxb649' },
     nativeCurrency: { name: 'Tron', symbol: 'TRX', decimals: 6 },
   },
   {

--- a/src/cli/services/intent-publish-flow.service.ts
+++ b/src/cli/services/intent-publish-flow.service.ts
@@ -126,6 +126,7 @@ export class IntentPublishFlow {
       sourcePortal: portalFromQuote,
       proverAddress: proverFromQuote,
       quote,
+      manualRewardDeadline,
     } = await this.fetchQuoteOrManualRoute({
       sourceChain,
       destChain,
@@ -154,7 +155,7 @@ export class IntentPublishFlow {
 
     const reward = this.intentBuilder.buildReward({
       sourceChain,
-      deadline: quote?.deadline,
+      deadline: quote?.deadline ?? manualRewardDeadline,
       creator: this.normalizer.normalize(
         senderAddress as Parameters<AddressNormalizerService['normalize']>[0],
         sourceChain.type
@@ -281,6 +282,10 @@ export class IntentPublishFlow {
     sourcePortal?: UniversalAddress;
     proverAddress?: UniversalAddress;
     quote?: QuoteResult;
+    // Manual-fallback only: reward deadline sized route + proving buffer so the
+    // solver's ExpirationValidation (fill->reward gap >= prover deadlineBuffer)
+    // accepts the intent. The quote path embeds this in quote.deadline instead.
+    manualRewardDeadline?: number;
   }> {
     const {
       sourceChain,
@@ -344,14 +349,22 @@ export class IntentPublishFlow {
         destChain.type
       );
 
+      // Route deadline: how long the solver has to fulfill (default offset).
+      // Reward deadline: route + proving buffer, so provers with a large
+      // deadlineBuffer (e.g. Polymer on Tron corridors, 86400s) don't reject it.
+      const routeDeadline =
+        BigInt(Math.floor(Date.now() / 1000)) + BigInt(this.config.getDeadlineOffsetSeconds());
+      const rewardDeadline = routeDeadline + BigInt(this.config.getRewardDeadlineBufferSeconds());
+
       const { encodedRoute } = this.intentBuilder.buildManualRoute({
         destChain,
         recipient,
         routeToken: routeTokenUniversal,
         routeAmount,
         portal: destPortal,
+        deadline: routeDeadline,
       });
-      return { encodedRoute };
+      return { encodedRoute, manualRewardDeadline: Number(rewardDeadline) };
     }
   }
 

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -65,6 +65,10 @@ export class ConfigService {
     return this.config.get<number>('DEADLINE_OFFSET_SECONDS') ?? 9000;
   }
 
+  getRewardDeadlineBufferSeconds(): number {
+    return this.config.get<number>('REWARD_DEADLINE_BUFFER_SECONDS') ?? 87000;
+  }
+
   getDappId(): string {
     return this.config.get<string>('DAPP_ID') ?? 'eco-routes-cli';
   }

--- a/src/config/validation/env.schema.ts
+++ b/src/config/validation/env.schema.ts
@@ -25,6 +25,10 @@ export const EnvSchema = z.object({
 
   DAPP_ID: z.string().default('eco-routes-cli'),
   DEADLINE_OFFSET_SECONDS: z.coerce.number().positive().default(9000),
+  // Gap between the manual-fallback route deadline and reward deadline. Must be
+  // at least the destination prover's proving buffer (Polymer Tron corridors run
+  // 86400s) or the solver permanently rejects the intent at ExpirationValidation.
+  REWARD_DEADLINE_BUFFER_SECONDS: z.coerce.number().positive().default(87000),
 });
 
 export type EnvConfig = z.infer<typeof EnvSchema>;

--- a/src/shared/types/chain-config.ts
+++ b/src/shared/types/chain-config.ts
@@ -1,7 +1,7 @@
 import { ChainType } from './intent.interface';
 import { UniversalAddress } from './universal-address';
 
-export const PROVER_TYPES = ['LayerZero', 'Hyperlane'] as const;
+export const PROVER_TYPES = ['LayerZero', 'Hyperlane', 'Polymer'] as const;
 export type ProverType = (typeof PROVER_TYPES)[number];
 
 export interface ChainConfig {

--- a/tests/cli/intent-publish-flow.test.ts
+++ b/tests/cli/intent-publish-flow.test.ts
@@ -105,7 +105,11 @@ function buildFlow(): FlowMocks {
   const statusService = { watch: jest.fn().mockResolvedValue('fulfilled') };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const config: any = { getKeyForChainType: () => TEST_PRIVATE_KEY };
+  const config: any = {
+    getKeyForChainType: () => TEST_PRIVATE_KEY,
+    getDeadlineOffsetSeconds: () => 9000,
+    getRewardDeadlineBufferSeconds: () => 87000,
+  };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const normalizer: any = { normalize: () => FAKE_UNIVERSAL };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -192,6 +196,31 @@ describe('IntentPublishFlow.publish', () => {
       },
     });
     expect(intentBuilder.buildManualRoute).toHaveBeenCalledTimes(1);
+  });
+
+  it('manual fallback spaces the reward deadline a proving buffer past the route deadline', async () => {
+    const { flow, quoteService, intentBuilder } = buildFlow();
+    quoteService.getQuote.mockRejectedValueOnce(new Error('quote down'));
+
+    const before = BigInt(Math.floor(Date.now() / 1000));
+    await flow.publish({
+      sourceChain: SOURCE_CHAIN,
+      destChain: DEST_CHAIN,
+      options: { privateKey: TEST_PRIVATE_KEY },
+      overrides: {
+        rewardToken: TOKEN_USDC,
+        routeToken: TOKEN_USDC,
+        rewardAmount: 1_000_000n,
+        recipientRaw: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+      },
+    });
+
+    const routeDeadline = intentBuilder.buildManualRoute.mock.calls[0][0].deadline as bigint;
+    const rewardDeadline = intentBuilder.buildReward.mock.calls[0][0].deadline as number;
+    expect(routeDeadline).toBeGreaterThanOrEqual(before + 9000n);
+    // Zero gap gets permanently rejected by the solver's ExpirationValidation;
+    // the reward deadline must sit a full proving buffer past the route deadline.
+    expect(BigInt(rewardDeadline)).toBe(routeDeadline + 87000n);
   });
 
   it('dry-run skips publishing and returns null', async () => {


### PR DESCRIPTION
## What

Makes Tron↔Base (chain 728126428, v2.6 Polymer mesh) publishable through the CLI. Three changes:

### 1. Tron chain config → v2.6 portal + Polymer prover
The Tron entry pointed at the old portal (`TTXNcSeX…`) with its LayerZero prover — that pairing cannot prove v2.6 intents, and it's not what production solvers (yellow, magenta) run. The entry now carries the v2.6 portal `TT6jKgnBXoj7vZ7m2Yioq5mxTfrDpgir44` with its paired Polymer prover `TLvVHqZZbs4Juf7umHYAepYgZkSdKxb649`. The old LayerZero entry is removed rather than kept alongside: portal and prover must stay paired, and leaving it would let prover auto-selection silently pick a broken combination.

`Polymer` joins `PROVER_TYPES`, and the EVM-side prover `0xE3e4e6F284f1c8E17bafE4268EB98c36886B4d8B` is listed on **Base only**. The same CREATE3 address exists on Ethereum/Optimism/Arbitrum/Polygon, but listing it there would give every EVM↔EVM pair two common prover types and break the single-common-prover auto-selection that non-interactive manual-fallback publishes rely on — the spawned-CLI integration test catches exactly this. Other chains can still use `--prover-address`.

### 2. Manual-fallback deadline gap
The quote-failure fallback built the route and reward deadlines from the same offset — a zero fill→reward gap. Solvers running an `ExpirationValidation` proving buffer **permanently reject** such intents (any buffer > 0, not just Tron's). The reward deadline now sits `REWARD_DEADLINE_BUFFER_SECONDS` past the route deadline (new env, default 87000s = Polymer's 86400s Tron-corridor buffer + slack).

### 3. Tests
New test pins the fallback deadline gap (route ≥ now+offset, reward = route + buffer); the flow-test mock config grows the two getters. Full suite: **112/112 green**.

## Live verification (mainnet, solver-yellow)

- Base→Tron **11.05 USDC → 1 USDT** published through the manual fallback path with this branch: intent `0xdc37b504…8b84` — fulfilled on Tron in ~75s, proven on Base in ~2min, withdrawn in ~5min.
- Prover auto-selection confirmed: `Using prover 'Polymer' on Base: 0x…E3e4…` with no `--prover-address` flag.

## Notes

- Tron→Base through the normal quote path needs no CLI changes (quote responses override static config); this PR is what makes the **fallback** direction and prover selection work.
- `TVM_PRIVATE_KEY` (already in the env schema, raw hex without 0x) is required when Tron is the source.